### PR TITLE
Fix test-failure due to non-existing `const` `final` keywords

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
@@ -53,7 +53,7 @@ public class TopLevelResolver extends AbstractItemResolver {
         if (this.isAnnotationStart(ctx)) {
             completionItems.addAll(CompletionItemResolver
                     .getResolverByClass(ParserRuleAnnotationAttachmentResolver.class).resolveItems(ctx));
-        } else if (poppedTokens.size() >= 1 && poppedTokens.get(0).equals(ItemResolverConstants.PUBLIC_KEYWORD)) {
+        } else if (poppedTokens.size() >= 1 && isAccessModifierToken(poppedTokens.get(0))) {
             completionItems.addAll(addTopLevelItems(ctx));
             completionItems.addAll(this.populateBasicTypes(ctx.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)));
         } else if (itemResolver == null
@@ -92,6 +92,8 @@ public class TopLevelResolver extends AbstractItemResolver {
         completionItems.add(getStaticItem(Snippet.DEF_RECORD, snippetCapability));
         completionItems.add(getStaticItem(Snippet.DEF_ENDPOINT, snippetCapability));
         completionItems.add(getStaticItem(Snippet.KW_TYPE, snippetCapability));
+        completionItems.add(getStaticItem(Snippet.KW_FINAL, snippetCapability));
+        completionItems.add(getStaticItem(Snippet.KW_CONST, snippetCapability));
         completionItems.add(getStaticItem(Snippet.KW_PUBLIC, snippetCapability));
         completionItems.add(getStaticItem(Snippet.DEF_ERROR, snippetCapability));
         return completionItems;
@@ -111,5 +113,11 @@ public class TopLevelResolver extends AbstractItemResolver {
         }
 
         return completionItems;
+    }
+
+    private boolean isAccessModifierToken(String token) {
+        return token.equals(ItemResolverConstants.PUBLIC_KEYWORD)
+                || token.equals(ItemResolverConstants.CONST_KEYWORD)
+                || token.equals(ItemResolverConstants.FINAL_KEYWORD);
     }
 }


### PR DESCRIPTION
## Purpose
> Fixing the test failure in LS. This was due to code completion support for the `const` and `final` which was introduced in https://github.com/ballerina-platform/ballerina-lang/pull/10731/commits/4569e693e7fa12b0bf2a4838af57b19dd064bf2a is overwritten.