### PR TITLE
Remove 'maven-scm-publish-plugin' dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2134,12 +2134,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>${maven.scm.publish.plugin.version}</version>
-                    <!-- last version compatible with Maven 2: latest is configured in profile -->
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${maven.site.plugin.version}</version>
                 </plugin>
@@ -2385,7 +2379,6 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.resources.plugin.version>2.7</maven.resources.plugin.version>
         <maven.scm.plugin.version>1.9.4</maven.scm.plugin.version>
-        <maven.scm.publish.plugin.version>1.1</maven.scm.publish.plugin.version>
         <maven.site.plugin.version>3.5</maven.site.plugin.version>
         <maven.source.plugin.version>3.0.0</maven.source.plugin.version>
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>


### PR DESCRIPTION
## Purpose
This PR removes `maven-scm-publish-plugin` dependency.

Closes https://github.com/ballerina-platform/ballerina-lang/pull/13985.